### PR TITLE
Fix typo in equipment name 'Metal Bow'

### DIFF
--- a/src/model/equipment.ts
+++ b/src/model/equipment.ts
@@ -73,7 +73,7 @@ export const cryoknightEquipmentCategories: EquipmentCategory[] = [
         element: elements.necromae,
     },
     {
-        name: ' Metal Bow',
+        name: 'Metal Bow',
         hands: 2,
         type: 'ranged',
         speedTier: 1,


### PR DESCRIPTION
Removed an unnecessary leading space in the 'Metal Bow' name field to ensure consistency across equipment definitions. This improves data integrity and prevents potential mismatches or display issues.