### PR TITLE
Add GitHub Action to enforce package.json version bump

### DIFF
--- a/.github/workflows/enforce-version-bump.yml
+++ b/.github/workflows/enforce-version-bump.yml
@@ -1,0 +1,28 @@
+name: Enforce Version Bump
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check-version-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check package.json version bump
+        run: |
+          PREV_VERSION=$(git show HEAD~1:package.json | jq -r .version)
+          CURR_VERSION=$(jq -r .version package.json)
+          
+          if [ "$PREV_VERSION" = "$CURR_VERSION" ]; then
+            echo "Error: package.json version has not been updated."
+            exit 1
+          fi
+
+      - name: Success Message
+        run: echo "package.json version updated correctly!"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brighter-fights",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
This workflow checks if the version in package.json is updated in pull requests targeting the master branch. It ensures version consistency by comparing the current and previous version values. Pull requests without a version bump will fail the check.